### PR TITLE
textfield to dropdown list plus missing field

### DIFF
--- a/application/controllers/Equipment.php
+++ b/application/controllers/Equipment.php
@@ -31,7 +31,6 @@ class Equipment extends CI_Controller {
 
     public function equipment()
     {
-
         $crud = new grocery_CRUD();
 
         $crud->set_theme('flexigrid');
@@ -47,13 +46,19 @@ class Equipment extends CI_Controller {
         $crud->display_as('eIdNumber', 'Equipment ID Number')
             ->display_as('eName', 'Equipment Name')
             ->display_as('eReviewDate', 'Review Date')
-            ->display_as('enabled', 'Delete');
+            ->display_as('enabled', 'Delete')
+            ->display_as('eMntValue', 'Maintenance Value');
 
         $crud->field_type('enabled', 'dropdown', array('N' => 'Yes', 'Y' => 'No'));
+
+        // display dropdown menu for equipment maintenance value
+        // allowed values: 'consumable', 'shared'
+
+        $crud->field_type('eMntValue', 'dropdown', array('consumable' => 'consumable', 'shared' => 'shared'));
         
         $crud->where('enabled', 'Y');
 
-        $crud->fields('eIdNumber', 'eName', 'eReviewDate', 'enabled');
+        $crud->fields('eIdNumber', 'eName', 'eReviewDate', 'eMntValue', 'enabled');
 
         //form validation (could match database columns set to "not null")
         $crud->required_fields('eIdNumber', 'eName', 'eReviewDate', 'enabled');

--- a/application/controllers/Qualifications.php
+++ b/application/controllers/Qualifications.php
@@ -50,6 +50,11 @@ class Qualifications extends CI_Controller {
 
         $crud->field_type('enabled', 'dropdown', array('N' => 'Yes', 'Y' => 'No'));
 
+        // provide dropdown list menu to choose values for qulifications level
+        // due to constraint on values in database:
+        // 'basic', 'intermediate', 'advanced'
+        $crud->field_type('qLevel', 'dropdown', array('basic' => 'basic', 'intermediate' => 'intermediate', 'advanced' => 'advanced'));
+
         $crud->fields('qId', 'qName', 'qLevel', 'qAccBody', 'enabled');
 
         //form validation (could match database columns set to "not null")

--- a/application/controllers/Therapy.php
+++ b/application/controllers/Therapy.php
@@ -56,6 +56,15 @@ class Therapy extends CI_Controller {
 
         $crud->field_type('enabled', 'dropdown', array('N' => 'Yes', 'Y' => 'No'));
 
+        // provide dropdown list menu to choose therapy category
+        // either 'health' or 'beauty'
+
+        $crud->field_type('tCategory', 'dropdown', array('health' => 'health', 'beauty'=> 'beauty'));
+
+        // provide dropdown list menu to choose therapy type
+        // either 'individual' or group
+        $crud->field_type('tType', 'dropdown', array('individual'=> 'individual', 'group' => 'group'));
+
         $crud->where('enabled', 'Y');
         
         $crud->field_type('isOffered', 'dropdown', array('Y' => 'Yes', 'N' => 'No'));


### PR DESCRIPTION
Changed input type from textfield to dropdown list menu in:
Therapy
Qualifications
Equipment
Also added missing 'equipment maintenance value' in the add new equipment form